### PR TITLE
Add media parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ With Vanilla JavaScript (no UI toolkit)
 With React
 
     npm run start:react
+
+## Run tests
+
+    npm test

--- a/docs/CucumberBlockly.tsx
+++ b/docs/CucumberBlockly.tsx
@@ -32,6 +32,7 @@ export const CucumberBlockly: React.FunctionComponent<CucumberBlocklyProps> = ({
       initialGherkinSource,
       suggestions,
       expressions,
+      'media',
       (err, gherkinSource, workspaceXml) => {
         setError(err ? err.stack : undefined)
         setGherkinSource(gherkinSource || '')

--- a/docs/main-vanilla.ts
+++ b/docs/main-vanilla.ts
@@ -37,6 +37,7 @@ mount(
   gherkinSource,
   suggestions,
   expressions,
+  'media',
   (err, gherkinSource, workspaceXml) => {
     let $e: Element | null
     if (err && ($e = document.querySelector('#error'))) {

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -14,6 +14,7 @@ import { toolbox } from './toolbox.js'
  * @param gherkinSource the gherkin source used to build the initial blocks
  * @param suggestions suggestions built by @cucumber/language-service
  * @param expressions all the expressions from step definitions
+ * @param media where the media files are
  * @param onBlocklyChanged called with an error, new generated Gherkin source and the Blockly XML whenever the blockly
  * editor has changed.
  * @returns a function that disposes the Blockly workspace
@@ -23,6 +24,7 @@ export function mount(
   gherkinSource: string,
   suggestions: readonly Suggestion[],
   expressions: readonly Expression[],
+  media: string,
   onBlocklyChanged: (
     error: Error | undefined,
     gherkinSource: string | undefined,
@@ -33,7 +35,7 @@ export function mount(
   const options: BlocklyOptions = {
     readOnly: false,
     trashcan: true,
-    media: 'media/',
+    media,
     move: {
       scrollbars: true,
       drag: true,


### PR DESCRIPTION
Add a `media` parameter so client libraries can specify where the blockly media is (not always in the same place)